### PR TITLE
incompatible peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
       "tsc-declaration": "tsc --emitDeclarationOnly"
     },
     "peerDependencies": {
-        "react-native-gesture-handler": "^1.6.1",
-        "react-native-svg": "^12.1.0"
+        "react-native-gesture-handler": "^2.3.1",
+        "react-native-svg": "^12.3.0"
     },
     "devDependencies": {
         "@babel/core": "^7.8.6",


### PR DESCRIPTION
running into peer dependency conflicts because the version is pinned to only allow to `1.6.1` < `2.0.0` however the `devDependencies` show its using `2.3.1`